### PR TITLE
Fix serial port connections on Linux

### DIFF
--- a/src/plugins/scratch/unixSeriaPort2Ops.c
+++ b/src/plugins/scratch/unixSeriaPort2Ops.c
@@ -337,7 +337,10 @@ error:
 }
 
 int isSerialPortDev(char *s) {
-	return isPrefix("ttyusb", s);
+	return isPrefix("ttyusb", s) ||
+		isPrefix("ttys", s) ||
+		isPrefix("ttyacm", s) ||
+		isPrefix("rfcomm", s);
 }
 
 int isPrefix(char *prefix, char *s) {


### PR DESCRIPTION
add possibility to communicate with arduino boards that appears as ttyACM\* on linux,
with boards connected via bluetooth (rfcomm\* on linux) and with boards connected
via rs232 (ttyS*).
